### PR TITLE
Limit Formal Trace Length to 13

### DIFF
--- a/ee282/cva6-formal/cva6/insns/generate.py
+++ b/ee282/cva6-formal/cva6/insns/generate.py
@@ -74,6 +74,8 @@ def gencheck(func):
             print(f"set_engine_mode {{Ht}}",file=f)
             print(f"set_engineH_first_trace_attempt 5",file=f)
             print(f"prove -all -cover ",file=f)
+            print(f"set_max_trace_length 13",file=f)
+            print(f"set_prove_time_limit 0s",file=f)
             print(f"load_radix_file radix.txt", file=f)
             print(f"set_engine_mode {{I N}}",file=f)
             print(f"prove -all -assert",file=f)


### PR DESCRIPTION
In Programming Assignment 3, it says that we are to regard a proof with length 13 or more as a pass. However, by default JasperGold increases the length without bound, only terminating after a day. This change instead has JasperGold run indefinitely up to 13 cycles.