### PR TITLE
Only Check Writeback for `rd != 0`

### DIFF
--- a/ee282/cva6-formal/cva6/checks/rvfi_insn_check.sv
+++ b/ee282/cva6-formal/cva6/checks/rvfi_insn_check.sv
@@ -58,7 +58,10 @@ module rvfi_insn_check (
 					end
 
 					rd_addr_match_prop: assert(rvfi_spec.rd_addr == rvfi_i.rd_addr);
-					rd_wdata_match_prop: assert(rvfi_spec.rd_wdata == rvfi_i.rd_wdata);
+					if (rvfi_spec.rd_addr != 0) begin
+						rd_wdata_match_prop: assert(rvfi_spec.rd_wdata == rvfi_i.rd_wdata);
+					end
+
 					pc_wdata_match_prop: assert(`rvformal_addr_eq(rvfi_spec.pc_wdata, rvfi_i.pc_wdata));
 
 					if (rvfi_spec.mem_wmask || rvfi_spec.mem_rmask) begin


### PR DESCRIPTION
RVFI states that `rvfi_rd_wdata` MUST be zero when `rd` is zero. However, CVA6 does not seem to follow this rule. Specifically, stores output the value written to memory on that signal instead. But, this is not a correctness issue since the destination register is zero.

To accomodate this implementation, this commit only checks that `rvfi_rd_wdata` matches the specification if the destination register is non-zero. If it is zero, the write will be ignored, so we don't need to check the value.